### PR TITLE
Fix/part versions

### DIFF
--- a/file2parts.go
+++ b/file2parts.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-fsnotify/fsnotify"
+	"github.com/fsnotify/fsnotify"
 	_ "github.com/go-sql-driver/mysql"
 	redis "gopkg.in/redis.v5"
 )


### PR DESCRIPTION
CMS Ver4案件で使用できるよう、partsのrestore時にparts_versionsも更新するよう修正しました。
「公開中のparts_versions」に対し上書き更新を行うようにしています。
この挙動で問題ないか、ご確認いただけますでしょうか。

また使用されていた"go-fsnotify/fsnotify"ライブラリですが、元のままではbuildが通らず依存関係を"fsnotify/fsnotify"に変更する必要がありましたので、こちらも記述変更しました。（アカウント移行されたようです）
https://github.com/go-fsnotify/fsnotify
こちらも問題ないかご確認いただければと思います。